### PR TITLE
Slice upstream gamemaster.json to smaller files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,15 @@
   "bugs": {
     "url": "https://github.com/nrkn/pvpoke-node/issues"
   },
-  "homepage": "https://github.com/nrkn/pvpoke-node#readme"
+  "homepage": "https://github.com/nrkn/pvpoke-node#readme",
+  "devDependencies": {
+    "@types/download": "^6.2.4",
+    "@types/node": "^14.0.13"
+  },
+  "dependencies": {
+    "download": "^8.0.0",
+    "fs": "0.0.1-security",
+    "os": "^0.1.1",
+    "path": "^0.12.7"
+  }
 }

--- a/src/sandbox/slice-upstream-gm.ts
+++ b/src/sandbox/slice-upstream-gm.ts
@@ -1,0 +1,46 @@
+/* -*- mode: typescript; -*- */
+/* ========================================================================== *
+ *  This utility can slice PvPoke's `gamemaster.json' file into smaller files
+ *  for faster access.
+ *
+ *  Ideally will can be extended to parse the `GameMaster.json' file directly
+ *  from the app's APK.
+ * ========================================================================= */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { tmpdir } from 'os';
+import * as download from 'download';
+
+const pvpokeGMURL : string = 'https://raw.githubusercontent.com/' +
+                             'pvpoke/pvpoke/master/src/data/gamemaster.json';
+
+/* Add more keys here. Keys must be root keys from gamemaster.json */
+const targetKeys : string[] = [ 'moves', 'pokemon' ];
+
+
+const downloadGM = async ( outfile : string ) : Promise<void> =>
+  fs.writeFileSync( outfile, await download( pvpokeGMURL ) );
+
+const sliceKeyToFile = async ( gmJSON : any, key : string, outfile : string ) =>
+  fs.writeFileSync( outfile, JSON.stringify( gmJSON[key] ) );
+
+
+/* Download gamemaster.json to a temporary directory, and slice keys. */
+fs.mkdtemp( path.join( tmpdir(), 'gm-' ), async ( err, workDir ) => {
+  if ( err ) throw err;
+  const gmPath : string = path.join( workDir, 'gamemaster.json' );
+  await downloadGM( gmPath );
+  var gmData : string = await fs.readFileSync( gmPath, 'utf8' );
+  var gmJSON : any = JSON.parse( gmData );
+  await Promise.all( targetKeys.map( k => {
+    var outpath = path.join( __dirname, '../data/' + k + '.json' );
+    sliceKeyToFile( gmJSON, k, outpath );
+  } ) );
+  await fs.unlinkSync( gmPath );
+  await fs.rmdirSync( workDir );
+} );
+
+
+/* ========================================================================= */
+/* vim: set filetype=typescript : */


### PR DESCRIPTION
Added script to pull PvPoke's `gamemaster.json` and slice it by key into smaller JSON files under `dist/data/`. New keys can easily be added, and the opportunity for post-processing could be added.
Currently the keys `[ "moves", "pokemon" ]` are targeted.

Usage:
```
npm run build;
node ./dist/sandbox/slice-upstream-gm;
ls ./dist/data/;
# ==> moves.json pokemon.json
```